### PR TITLE
Fix for the table rendering issue described in #17 and added <thead> and <tbody> to the rendering of the table

### DIFF
--- a/micromarkdown.js
+++ b/micromarkdown.js
@@ -25,7 +25,7 @@ var micromarkdown = {
     reflinks: /\[([^\]]+)\]\[([^\]]+)\]/g,
     smlinks: /\@([a-z0-9]{3,})\@(t|gh|fb|gp|adn)/gi,
     mail: /<(([a-z0-9_\-\.])+\@([a-z0-9_\-\.])+\.([a-z]{2,7}))>/gmi,
-    tables: /\n(([^|\n]+ *\| *)+([^|\n]+\n))((:?\-+:?\|)+(:?\-+:?)*\n)((([^|\n]+ *\| *)+([^|\n]+)\n)+)/g,
+    tables: /\n(([^|\n]+ *\| *)+([^|\n]+\n))([\t ]*(:?\-+:?\|)+(:?\-+:?)*\n)((([^|\n]+ *\| *)+([^|\n]+)\n)+)/g,
     include: /[\[<]include (\S+) from (https?:\/\/[a-z0-9\.\-]+\.[a-z]{2,9}[a-z0-9\.\-\?\&\/]+)[\]>]/gi,
     url: /<([a-zA-Z0-9@:%_\+.~#?&\/=]{2,256}\.[a-z]{2,4}\b(\/[\-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)?)>/g,
     url2: /[ \t\n]([a-zA-Z]{2,16}:\/\/[a-zA-Z0-9@:%_\+.~#?&=]{2,256}.[a-z]{2,4}\b(\/[\-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)?)[ \t\n]/g
@@ -51,7 +51,7 @@ var micromarkdown = {
     while ((stra = micromarkdown.regexobject.code.exec(str)) !== null) {
       crc32str = micromarkdown.crc32(stra[0]);
       micromarkdown.codeblocks[crc32str] = '<code>\n' + micromarkdown.htmlEncode(stra[1]).replace(/\n/gm, '<br/>').replace(/\ /gm, '&nbsp;') + '</code>';
-      str = str.replace(stra[0], ' §§§' + crc32str + '§§§ '); 
+      str = str.replace(stra[0], ' §§§' + crc32str + '§§§ ');
     }
 
     /* headlines */
@@ -306,9 +306,9 @@ var micromarkdown = {
 
     str = str.replace(/[\n]{2,}/gmi, '<br/><br/>');
 
-    for(var index in micromarkdown.codeblocks) { 
+    for(var index in micromarkdown.codeblocks) {
       if(micromarkdown.codeblocks.hasOwnProperty(index)) {
-        str = str.replace('§§§' + index + '§§§', micromarkdown.codeblocks[index]); 
+        str = str.replace('§§§' + index + '§§§', micromarkdown.codeblocks[index]);
       }
     }
     str = str.replace('&#x0024&amp;', '$&');

--- a/micromarkdown.js
+++ b/micromarkdown.js
@@ -115,7 +115,7 @@ var micromarkdown = {
 
     /* tables */
     while ((stra = micromarkdown.regexobject.tables.exec(str)) !== null) {
-      repstr = '<table><tr>';
+      repstr = '<table>';
       helper = stra[1].split('|');
       calign = stra[4].split('|');
       for (i = 0; i < helper.length; i++) {
@@ -137,11 +137,13 @@ var micromarkdown = {
           calign[i] = 0;
         }
       }
+
+      repstr += "<thead><tr>"
       cel = ['<th>', '<th align="left">', '<th align="right">', '<th align="center">'];
       for (i = 0; i < helper.length; i++) {
         repstr += cel[calign[i]] + helper[i].trim() + '</th>';
       }
-      repstr += '</tr>';
+      repstr += '</tr></thead><tbody>';
       cel = ['<td>', '<td align="left">', '<td align="right">', '<td align="center">'];
       helper1 = stra[7].split('\n');
       for (i = 0; i < helper1.length; i++) {
@@ -157,7 +159,7 @@ var micromarkdown = {
           repstr += '</tr>' + '\n';
         }
       }
-      repstr += '</table>';
+      repstr += '</tbody></table>';
       str = str.replace(stra[0], repstr);
     }
 

--- a/test.html
+++ b/test.html
@@ -143,34 +143,34 @@
 </code>
 <code id="test_table">
 <!--
-this | is a   | table  
+this | is a   | table
 -----|--------|--------
 with | sample | content
-lorem| ipsum  | dolor  
-sit  | amet   | sed    
-do   | eiusom | tempor 
+lorem| ipsum  | dolor
+sit  | amet   | sed
+do   | eiusom | tempor
 |||
-<table><tr><th>this</th><th>is a</th><th>table</th></tr><tr><td>with</td><td>sample</td><td>content</td></tr>
+<table><thead><tr><th>this</th><th>is a</th><th>table</th></tr></thead><tbody><tr><td>with</td><td>sample</td><td>content</td></tr>
 <tr><td>lorem</td><td>ipsum</td><td>dolor</td></tr>
 <tr><td>sit</td><td>amet</td><td>sed</td></tr>
 <tr><td>do</td><td>eiusom</td><td>tempor</td></tr>
-</table>
+</tbody></table>
 -->
 </code>
 <code id="test_gfmtable">
 <!--
-this  | is a     | test    | table 
+this  | is a     | test    | table
 -----:|:--------:|:--------|-------
 with  |   sample | content | lorem
 lorem |   ipsum  | dolor   | ipsum
 sit   |   amet   | sed     | dolor
 do    |   eiusom | tempor  | sit a
 |||
-<table><tr><th align="right">this</th><th align="center">is a</th><th align="left">test</th><th>table</th></tr><tr><td align="right">with</td><td align="center">sample</td><td align="left">content</td><td>lorem</td></tr>
+<table><thead><tr><th align="right">this</th><th align="center">is a</th><th align="left">test</th><th>table</th></tr></thead><tbody><tr><td align="right">with</td><td align="center">sample</td><td align="left">content</td><td>lorem</td></tr>
 <tr><td align="right">lorem</td><td align="center">ipsum</td><td align="left">dolor</td><td>ipsum</td></tr>
 <tr><td align="right">sit</td><td align="center">amet</td><td align="left">sed</td><td>dolor</td></tr>
 <tr><td align="right">do</td><td align="center">eiusom</td><td align="left">tempor</td><td>sit a</td></tr>
-</table>
+</tbody></table>
 -->
 </code>
 <code id="test_code">
@@ -186,7 +186,7 @@ var&nbsp;md&nbsp;&nbsp;&nbsp;=&nbsp;document.getElementById("md").value,<br/>&nb
 </code>
 </div>
 <div class="result" id="result">
-  
+
 </div>
 <script type="text/javascript">
   var _gaq = _gaq || [];


### PR DESCRIPTION
This is a fix for #17.
The regex for table matching is extended to allow spaces and tabs as prefixes for the horizontal divider between head and body.
Also added the <thead>..</thead> elements around the <th> elements and the <tbody>...</tbody> around the <td> elements
